### PR TITLE
Maayankremer/json-patch-escape

### DIFF
--- a/cmd/webhook/annotations/azd_annotations_jsonpatch_generator.go
+++ b/cmd/webhook/annotations/azd_annotations_jsonpatch_generator.go
@@ -32,7 +32,7 @@ func CreateContainersVulnerabilityScanAnnotationPatchAdd(containersScanInfoList 
 	}
 
 	// Create an add operation to annotations to add or create if annotations are empty
-	patch := jsonpatch.NewOperation(_addPatchOperation, _annotationPatchPath, map[string]string{contracts.ContainersVulnerabilityScanInfoAnnotationName: serVulnerabilitySecInfo})
+	patch := jsonpatch.NewOperation(_addPatchOperation, _annotationPatchPath + contracts.ContainersVulnerabilityScanInfoAnnotationName, serVulnerabilitySecInfo)
 	return &patch, nil
 }
 

--- a/cmd/webhook/annotations/azd_annotations_jsonpatch_generator_test.go
+++ b/cmd/webhook/annotations/azd_annotations_jsonpatch_generator_test.go
@@ -11,7 +11,7 @@ import (
 
 const (
 	_expectedTestAddPatchOperation   = "add"
-	_expectedTestAnnotationPatchPath = "/metadata/annotations"
+	_expectedTestAnnotationPatchPath = "/metadata/annotations/azuredefender.io~1containers.vulnerability.scan.info"	// '~1' is json patch escape to '/'
 )
 
 type TestSuite struct {
@@ -61,11 +61,7 @@ func (suite *TestSuite) Test_CreateContainersVulnerabilityScanAnnotationPatchAdd
 	suite.Equal(_expectedTestAnnotationPatchPath, result.Path)
 
 	// Get data string
-	mapAnnotations, ok := result.Value.(map[string]string)
-	suite.True(ok)
-
-	suite.Equal(1, len(mapAnnotations))
-	strValue, ok := mapAnnotations[contracts.ContainersVulnerabilityScanInfoAnnotationName]
+	strValue, ok := result.Value.(string)
 	suite.True(ok)
 
 	// Unmarshal

--- a/cmd/webhook/handler_test.go
+++ b/cmd/webhook/handler_test.go
@@ -24,7 +24,7 @@ import (
 
 const (
 	_expectedTestAddPatchOperation   = "add"
-	_expectedTestAnnotationPatchPath = "/metadata/annotations"
+	_expectedTestAnnotationPatchPath = "/metadata/annotations/azuredefender.io~1containers.vulnerability.scan.info"	// '~1' is json patch escape to '/'
 )
 
 var (
@@ -65,7 +65,6 @@ func (suite *TestSuite) Test_Handle_DryRunTrue_ShouldNotPatched() {
 	req := createRequestForTests(pod)
 	expectedInfo := []*contracts.ContainerVulnerabilityScanInfo{_firstContainerVulnerabilityScanInfo}
 	suite.azdSecProviderMock.On("GetContainersVulnerabilityScanInfo", &pod.Spec, &pod.ObjectMeta, &pod.TypeMeta).Return(expectedInfo, nil).Once()
-
 	handler := NewHandler(suite.azdSecProviderMock, &HandlerConfiguration{DryRun: true}, instrumentation.NewNoOpInstrumentationProvider())
 	// Act
 	resp := handler.Handle(context.Background(), *req)
@@ -201,11 +200,7 @@ func (suite *TestSuite) checkPatch(expected []*contracts.ContainerVulnerabilityS
 	suite.Equal(_expectedTestAnnotationPatchPath, patch.Path)
 
 	// Get data string
-	mapAnnotations, ok := patch.Value.(map[string]string)
-	suite.True(ok)
-
-	suite.Equal(1, len(mapAnnotations))
-	strValue, ok := mapAnnotations[contracts.ContainersVulnerabilityScanInfoAnnotationName]
+	strValue, ok := patch.Value.(string)
 	suite.True(ok)
 
 	// Unmarshal

--- a/pkg/azdsecinfo/contracts/containers_vulnerability_scan_info.go
+++ b/pkg/azdsecinfo/contracts/containers_vulnerability_scan_info.go
@@ -5,8 +5,11 @@ import (
 )
 
 const (
+	// '~1' is json patch escape to '/'
+	_jsonPatchEscape = "~1"
+
 	AzdSecInfoAnnotationPrefix                    = "/azuredefender.io"
-	ContainersVulnerabilityScanInfoAnnotationName = AzdSecInfoAnnotationPrefix + "~1containers.vulnerability.scan.info" // '~1' is json patch escape to '/'
+	ContainersVulnerabilityScanInfoAnnotationName = AzdSecInfoAnnotationPrefix + _jsonPatchEscape + "containers.vulnerability.scan.info"
 )
 
 // ScanStatus Enum

--- a/pkg/azdsecinfo/contracts/containers_vulnerability_scan_info.go
+++ b/pkg/azdsecinfo/contracts/containers_vulnerability_scan_info.go
@@ -5,8 +5,8 @@ import (
 )
 
 const (
-	AzdSecInfoAnnotationPrefix                    = "azuredefender.io"
-	ContainersVulnerabilityScanInfoAnnotationName = AzdSecInfoAnnotationPrefix + "/containers.vulnerability.scan.info"
+	AzdSecInfoAnnotationPrefix                    = "/azuredefender.io"
+	ContainersVulnerabilityScanInfoAnnotationName = AzdSecInfoAnnotationPrefix + "~1containers.vulnerability.scan.info" // '~1' is json patch escape to '/'
 )
 
 // ScanStatus Enum


### PR DESCRIPTION
Fix annotations override by using json patch escape for '/'
I tested it by:
1. Using https://json-schema-validator.herokuapp.com/jsonpatch.jsp
2. Manually deploying pod with annotations