### PR TITLE
Maayankremer/add-annotations-map

### DIFF
--- a/cmd/webhook/annotations/azd_annotations_jsonpatch_generator.go
+++ b/cmd/webhook/annotations/azd_annotations_jsonpatch_generator.go
@@ -39,6 +39,7 @@ func CreateContainersVulnerabilityScanAnnotationPatchAdd(containersScanInfoList 
 	annotations[contracts.ContainersVulnerabilityScanInfoAnnotationName] = serVulnerabilitySecInfo
 
 	// Create an add operation to annotations to add or create if annotations are empty
+	// **important note** any future changes to the map will result in changing the patch.
 	patch := jsonpatch.NewOperation(_addPatchOperation, _annotationPatchPath, annotations)
 	return &patch, nil
 }

--- a/cmd/webhook/annotations/azd_annotations_jsonpatch_generator_test.go
+++ b/cmd/webhook/annotations/azd_annotations_jsonpatch_generator_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"github.com/Azure/AzureDefender-K8S-InClusterDefense/pkg/azdsecinfo/contracts"
 	"github.com/stretchr/testify/suite"
+	corev1 "k8s.io/api/core/v1"
 	"reflect"
 	"testing"
 	"time"
@@ -55,7 +56,7 @@ func (suite *TestSuite) SetupSuite() {
 }
 
 func (suite *TestSuite) Test_CreateContainersVulnerabilityScanAnnotationPatchAdd_TwoContainersScanInfo_AnnotationsGeneratedAsExpected() {
-	result, err := CreateContainersVulnerabilityScanAnnotationPatchAdd(suite.containersScanInfo)
+	result, err := CreateContainersVulnerabilityScanAnnotationPatchAdd(suite.containersScanInfo, &corev1.Pod{})
 	suite.Nil(err)
 	suite.Equal(_expectedTestAddPatchOperation, result.Operation)
 	suite.Equal(_expectedTestAnnotationPatchPath, result.Path)

--- a/cmd/webhook/annotations/azd_annotations_jsonpatch_generator_test.go
+++ b/cmd/webhook/annotations/azd_annotations_jsonpatch_generator_test.go
@@ -5,7 +5,7 @@ import (
 	"github.com/Azure/AzureDefender-K8S-InClusterDefense/pkg/azdsecinfo/contracts"
 	"github.com/stretchr/testify/suite"
 	corev1 "k8s.io/api/core/v1"
-	"reflect"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"testing"
 	"time"
 )
@@ -13,11 +13,17 @@ import (
 const (
 	_expectedTestAddPatchOperation   = "add"
 	_expectedTestAnnotationPatchPath = "/metadata/annotations"
+	_annotationTestKeyOne = "cluster-autoscaler.kubernetes.io/safe-to-evict"
+	_annotationTestValueOne = "true"
+	_annotationTestKeyTwo = "container.seccomp.security.alpha.kubernetes.io/manager"
+	_annotationTestValueTwo = "runtime/default"
 )
 
 type TestSuite struct {
 	suite.Suite
 	containersScanInfo []*contracts.ContainerVulnerabilityScanInfo
+	podNoAnnotations *corev1.Pod
+	podWithAnnotations *corev1.Pod
 }
 
 func (suite *TestSuite) SetupSuite() {
@@ -53,36 +59,69 @@ func (suite *TestSuite) SetupSuite() {
 			},
 		},
 	}
+	suite.podNoAnnotations = &corev1.Pod{}
+	suite.podWithAnnotations = createPodWithAnnotationsForTest()
 }
 
 func (suite *TestSuite) Test_CreateContainersVulnerabilityScanAnnotationPatchAdd_TwoContainersScanInfo_AnnotationsGeneratedAsExpected() {
-	result, err := CreateContainersVulnerabilityScanAnnotationPatchAdd(suite.containersScanInfo, &corev1.Pod{})
+	suite.checkContainersVulnerabilityScanAnnotation(1, suite.podNoAnnotations)
+}
+
+func (suite *TestSuite) Test_CreateContainersVulnerabilityScanAnnotationPatchAdd_PodWithAnnotations_AnnotationsGeneratedAsExpected() {
+
+	// check containers vulnerability scan annotations
+	mapAnnotations := suite.checkContainersVulnerabilityScanAnnotation(3, suite.podWithAnnotations)
+
+	// check no override of existing annotations
+	suite.checkNoOverrideOfExistingAnnotations(mapAnnotations, _annotationTestKeyOne, _annotationTestValueOne)
+	suite.checkNoOverrideOfExistingAnnotations(mapAnnotations, _annotationTestKeyTwo, _annotationTestValueTwo)
+}
+
+func (suite *TestSuite)checkContainersVulnerabilityScanAnnotation(patchLen int, pod *corev1.Pod) map[string]string{
+	result, err := CreateContainersVulnerabilityScanAnnotationPatchAdd(suite.containersScanInfo, pod)
 	suite.Nil(err)
 	suite.Equal(_expectedTestAddPatchOperation, result.Operation)
 	suite.Equal(_expectedTestAnnotationPatchPath, result.Path)
 
-	// Get data string
 	mapAnnotations, ok := result.Value.(map[string]string)
 	suite.True(ok)
 
-	suite.Equal(1, len(mapAnnotations))
-	strValue, ok := mapAnnotations[contracts.ContainersVulnerabilityScanInfoAnnotationName]
+	suite.Equal(patchLen, len(mapAnnotations))
+	strContainersVulnerabilityScanValue, ok := mapAnnotations[contracts.ContainersVulnerabilityScanInfoAnnotationName]
 	suite.True(ok)
 
 	// Unmarshal
 	scanInfoList := new(contracts.ContainerVulnerabilityScanInfoList)
-	err = json.Unmarshal([]byte(strValue), scanInfoList)
+	err = json.Unmarshal([]byte(strContainersVulnerabilityScanValue), scanInfoList)
 	suite.Nil(err)
 
 	// Verify timestamp
 	diff := time.Now().UTC().Sub(scanInfoList.GeneratedTimestamp)
 	suite.True((diff >= 0 && diff < time.Second))
 	suite.Equal(time.UTC, scanInfoList.GeneratedTimestamp.Location())
+	return mapAnnotations
+}
 
-	// Verify containers slice deep equal verification
-	suite.True(reflect.DeepEqual(suite.containersScanInfo, scanInfoList.Containers))
+func (suite *TestSuite)checkNoOverrideOfExistingAnnotations(mapAnnotations map[string]string, expectedKey string, expectedVal string){
+	strAnnotationField1, ok := mapAnnotations[expectedKey]
+	suite.True(ok)
+	suite.Equal(expectedVal, strAnnotationField1)
 }
 
 func TestCreateContainersVulnerabilityScanAnnotationPatchAdd(t *testing.T) {
 	suite.Run(t, new(TestSuite))
+}
+
+func createPodWithAnnotationsForTest() *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "podTest",
+			Annotations: map[string]string{
+				_annotationTestKeyOne : _annotationTestValueOne,
+				_annotationTestKeyTwo : _annotationTestValueTwo,
+			},
+		},
+		TypeMeta: metav1.TypeMeta{},
+		Spec: corev1.PodSpec{},
+	}
 }

--- a/cmd/webhook/handler.go
+++ b/cmd/webhook/handler.go
@@ -142,7 +142,7 @@ func (handler *Handler) getPodContainersVulnerabilityScanInfoAnnotationsOperatio
 	tracer.Info("vulnSecInfoContainers", "vulnSecInfoContainers", vulnSecInfoContainers)
 
 	// Create the annotations add json patch operation
-	vulnerabilitySecAnnotationsPatch, err := annotations.CreateContainersVulnerabilityScanAnnotationPatchAdd(vulnSecInfoContainers)
+	vulnerabilitySecAnnotationsPatch, err := annotations.CreateContainersVulnerabilityScanAnnotationPatchAdd(vulnSecInfoContainers, pod)
 	if err != nil {
 		wrappedError := errors.Wrap(err, "Handler failed to CreateContainersVulnerabilityScanAnnotationPatchAdd")
 		tracer.Error(wrappedError, "Handler.annotations.CreateContainersVulnerabilityScanAnnotationPatchAdd")

--- a/cmd/webhook/handler_test.go
+++ b/cmd/webhook/handler_test.go
@@ -259,3 +259,20 @@ func createPodForTests(containers []corev1.Container, initContainers []corev1.Co
 		},
 	}
 }
+//
+//func createPodWithAnnotationsForTests(containers []corev1.Container, initContainers []corev1.Container) *corev1.Pod {
+//	return &corev1.Pod{
+//		ObjectMeta: metav1.ObjectMeta{
+//			Name: "podTest",
+//			Annotations: map[string]string{
+//				"cluster-autoscaler.kubernetes.io/safe-to-evict" : "true",
+//				"container.seccomp.security.alpha.kubernetes.io/manager" : "runtime/default",
+//			},
+//		},
+//		TypeMeta: metav1.TypeMeta{},
+//		Spec: corev1.PodSpec{
+//			Containers:     containers,
+//			InitContainers: initContainers,
+//		},
+//	}
+//}

--- a/cmd/webhook/handler_test.go
+++ b/cmd/webhook/handler_test.go
@@ -259,20 +259,3 @@ func createPodForTests(containers []corev1.Container, initContainers []corev1.Co
 		},
 	}
 }
-//
-//func createPodWithAnnotationsForTests(containers []corev1.Container, initContainers []corev1.Container) *corev1.Pod {
-//	return &corev1.Pod{
-//		ObjectMeta: metav1.ObjectMeta{
-//			Name: "podTest",
-//			Annotations: map[string]string{
-//				"cluster-autoscaler.kubernetes.io/safe-to-evict" : "true",
-//				"container.seccomp.security.alpha.kubernetes.io/manager" : "runtime/default",
-//			},
-//		},
-//		TypeMeta: metav1.TypeMeta{},
-//		Spec: corev1.PodSpec{
-//			Containers:     containers,
-//			InitContainers: initContainers,
-//		},
-//	}
-//}


### PR DESCRIPTION
No annotations override.

Matching webhooks are called in serial; each one may modify the object if it desires. - https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers

Please note the json patch is created by the pod's annotations map. Any changes to the pod's map after the creation of the patch will result in changing the patch.
Two options:
1. Be careful not to change the map afterwards (documented)- performance efficient
2. Make a deep copy of the map - safer

In addition:
1. All tests passed
2. a test has been added
3. Checked manually healthy and unhealthy pods with and without annotations, by apply and run.

Implementation example - https://github.com/open-policy-agent/gatekeeper/blob/eeb7bff4871899e29d1c1201f22210ffdb8e9114/pkg/mutation/annotations.go
line 17 