### PR TITLE
change redis image to be pulled from mcr

### DIFF
--- a/charts/azdproxy/values-dev.yaml
+++ b/charts/azdproxy/values-dev.yaml
@@ -141,7 +141,7 @@ AzDProxy:
 
     redisClient:
       #  -- Image of redis containers
-      image: redis:6
+      image: azuredefendermcrdev.azurecr.io/public/azuredefender/dev/in-cluster-defense-redis
       # -- amount of replicas of redis
       replicas: 1
       # -- the port that redis cache will be listened.

--- a/charts/azdproxy/values.yaml
+++ b/charts/azdproxy/values.yaml
@@ -140,7 +140,7 @@ AzDProxy:
   cache:
     redisClient:
       # Image of redis containers
-      image: redis:6
+      image: azuredefendermcrdev.azurecr.io/public/azuredefender/dev/in-cluster-defense-redis
       # -- amount of replicas of redis
       replicas: 1
       # -- the port that redis cache will be listened.


### PR DESCRIPTION
Used the following registry -
azuredefendermcrdev.azurecr.io/public/azuredefender/dev/in-cluster-defense-redis
according to:
https://github.com/microsoft/mcr/blob/e7a8d3db7298e817040b7a40dac9d385ae14d801/teams/azuredefender/detection-dev.yaml#L86

The image was pushed to MCR - https://ms.portal.azure.com/#@microsoft.onmicrosoft.com/resource/subscriptions/4009f3ee-43c4-4f19-97e4-32b6f2285a68/resourceGroups/AzureDefender-MCR-Dev/providers/Microsoft.ContainerRegistry/registries/azuredefendermcrdev/repository 